### PR TITLE
Treat source files as text

### DIFF
--- a/T3000/.gitattributes
+++ b/T3000/.gitattributes
@@ -1,0 +1,1 @@
+*.cpp set diff


### PR DESCRIPTION
This forces git to treat all *.cpp files in the T3000 folder as text,
even if they contain strange chinese characters .

Fix for ticket #23 mainfame.cpp showing as binary
