### PR TITLE
Fix Selection On Monitor To Left/Above Main Monitor

### DIFF
--- a/Modbus Poll/DeviecTesterConfigDlg.cpp
+++ b/Modbus Poll/DeviecTesterConfigDlg.cpp
@@ -99,7 +99,7 @@ void CDeviecTesterConfigDlg::OnNMDblclkListDevice(NMHDR *pNMHDR, LRESULT *pResul
 	long lRow,lCol;
 	 
 	DWORD dwPos=GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-	CPoint point( LOWORD(dwPos), HIWORD(dwPos));
+	CPoint point( GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
 	m_devices_list.ScreenToClient(&point);
 	LVHITTESTINFO lvinfo;
 	lvinfo.pt=point;

--- a/T3000/AirQuality/AirQuality.cpp
+++ b/T3000/AirQuality/AirQuality.cpp
@@ -3237,7 +3237,7 @@ void CAirQuality::OnNMClickList1_AQ(NMHDR* pNMHDR, LRESULT* pResult)
 	long lRow, lCol;
 	m_input_list.Set_Edit(true);
 	DWORD dwPos = GetMessagePos();//Get which line is clicked by user. Set the check box, when user enter Insert it will jump to dialog
-	CPoint point(LOWORD(dwPos), HIWORD(dwPos));
+	CPoint point(GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
 	m_input_list.ScreenToClient(&point);
 	LVHITTESTINFO lvinfo;
 	lvinfo.pt = point;
@@ -3400,7 +3400,7 @@ void CAirQuality::OnNMClickList2_AQ(NMHDR* pNMHDR, LRESULT* pResult)
 	DWORD dwPos = GetMessagePos();
 	//Get which line has been clicked by user.
      //Set the check box, when user hits Insert jump to dialog
-	CPoint point(LOWORD(dwPos), HIWORD(dwPos));
+	CPoint point(GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
 	m_output_list.ScreenToClient(&point);
 	LVHITTESTINFO lvinfo;
 	lvinfo.pt = point;
@@ -3430,7 +3430,7 @@ void CAirQuality::OnNMClickList_User(NMHDR* pNMHDR, LRESULT* pResult)
 	m_factory_list.Set_Edit(true);
 	DWORD dwPos = GetMessagePos();//Get which line has been clicked
       					//Set the check box, when user hits Insert jump to the dialog
-	CPoint point(LOWORD(dwPos), HIWORD(dwPos));
+	CPoint point(GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
 	m_factory_list.ScreenToClient(&point);
 	LVHITTESTINFO lvinfo;
 	lvinfo.pt = point;

--- a/T3000/BacnetAlarmLog.cpp
+++ b/T3000/BacnetAlarmLog.cpp
@@ -337,7 +337,7 @@ void CBacnetAlarmLog::OnClickListAlarmlog(NMHDR *pNMHDR, LRESULT *pResult)
 	long lRow,lCol;
 	m_alarmlog_list.Set_Edit(true);
 	DWORD dwPos=GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-	CPoint point( LOWORD(dwPos), HIWORD(dwPos));
+	CPoint point( GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
 	m_alarmlog_list.ScreenToClient(&point);
 	LVHITTESTINFO lvinfo;
 	lvinfo.pt=point;

--- a/T3000/BacnetAnalogCusRang.cpp
+++ b/T3000/BacnetAnalogCusRang.cpp
@@ -1576,7 +1576,7 @@ void CBacnetAnalogCusRang::OnNMClickDialogBacnetRangeList(NMHDR *pNMHDR, LRESULT
     long lRow, lCol;
     m_analog_cus_range_list.Set_Edit(false);
     DWORD dwPos = GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-    CPoint point(LOWORD(dwPos), HIWORD(dwPos));
+    CPoint point(GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
     m_analog_cus_range_list.ScreenToClient(&point);
     LVHITTESTINFO lvinfo;
     lvinfo.pt = point;

--- a/T3000/BacnetAnnualRoutine.cpp
+++ b/T3000/BacnetAnnualRoutine.cpp
@@ -257,7 +257,7 @@ void BacnetAnnualRoutine::OnNMClickListBacAnnuleList(NMHDR *pNMHDR, LRESULT *pRe
 	
 
 	DWORD dwPos=GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-	CPoint point( LOWORD(dwPos), HIWORD(dwPos));
+	CPoint point( GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
 	m_annualr_list.ScreenToClient(&point);
 	LVHITTESTINFO lvinfo;
 	lvinfo.pt=point;

--- a/T3000/BacnetController.cpp
+++ b/T3000/BacnetController.cpp
@@ -1051,7 +1051,7 @@ void BacnetController::OnNMClickListController(NMHDR *pNMHDR, LRESULT *pResult)
 	long lRow,lCol;
 	m_controller_list.Set_Edit(true);
 	DWORD dwPos=GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-	CPoint point( LOWORD(dwPos), HIWORD(dwPos));
+	CPoint point( GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
 	m_controller_list.ScreenToClient(&point);
 	LVHITTESTINFO lvinfo;
 	lvinfo.pt=point;

--- a/T3000/BacnetCustomerDigitalRange.cpp
+++ b/T3000/BacnetCustomerDigitalRange.cpp
@@ -230,7 +230,7 @@ void CBacnetCustomerDigitalRange::OnNMClickListCustomerDigitalRange(NMHDR *pNMHD
 	long lRow,lCol;
 	m_customer_dig_range_list.Set_Edit(true);
 	DWORD dwPos=GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-	CPoint point( LOWORD(dwPos), HIWORD(dwPos));
+	CPoint point( GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
 	m_customer_dig_range_list.ScreenToClient(&point);
 	LVHITTESTINFO lvinfo;
 	lvinfo.pt=point;

--- a/T3000/BacnetIOConfig.cpp
+++ b/T3000/BacnetIOConfig.cpp
@@ -473,7 +473,7 @@ void CBacnetIOConfig::OnNMClickListIoconfig(NMHDR* pNMHDR, LRESULT* pResult)
 	LPNMITEMACTIVATE pNMItemActivate = reinterpret_cast<LPNMITEMACTIVATE>(pNMHDR);
 	
 	DWORD dwPos = GetMessagePos();
-	CPoint point(LOWORD(dwPos), HIWORD(dwPos));
+	CPoint point(GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
 	m_ext_io_config_list.ScreenToClient(&point);
 	LVHITTESTINFO lvinfo;
 	lvinfo.pt = point;

--- a/T3000/BacnetInput.cpp
+++ b/T3000/BacnetInput.cpp
@@ -1171,7 +1171,7 @@ void CBacnetInput::OnNMClickList1(NMHDR *pNMHDR, LRESULT *pResult)
 	long lRow,lCol;
 	m_input_list.Set_Edit(true);
 	DWORD dwPos=GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-	CPoint point( LOWORD(dwPos), HIWORD(dwPos));
+	CPoint point( GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
 	m_input_list.ScreenToClient(&point);
 	LVHITTESTINFO lvinfo;
 	lvinfo.pt=point;

--- a/T3000/BacnetMonitor.cpp
+++ b/T3000/BacnetMonitor.cpp
@@ -965,7 +965,7 @@ void CBacnetMonitor::OnNMClickListMonitor(NMHDR *pNMHDR, LRESULT *pResult)
 	CString temp_task_info;
 	
 	DWORD dwPos=GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-	CPoint point( LOWORD(dwPos), HIWORD(dwPos));
+	CPoint point( GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
 	m_monitor_list.ScreenToClient(&point);
 	LVHITTESTINFO lvinfo;
 	lvinfo.pt=point;

--- a/T3000/BacnetOutput.cpp
+++ b/T3000/BacnetOutput.cpp
@@ -1146,7 +1146,7 @@ void CBacnetOutput::OnNMClickListOutput(NMHDR *pNMHDR, LRESULT *pResult)
 	long lRow,lCol;
 	m_output_list.Set_Edit(true);
 	DWORD dwPos=GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-	CPoint point( LOWORD(dwPos), HIWORD(dwPos));
+	CPoint point( GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
 	m_output_list.ScreenToClient(&point);
 	LVHITTESTINFO lvinfo;
 	lvinfo.pt=point;
@@ -1885,7 +1885,7 @@ void CBacnetOutput::OnNMRClickListOutput(NMHDR *pNMHDR, LRESULT *pResult)
     long lRow, lCol;
     m_output_list.Set_Edit(true);
     DWORD dwPos = GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-    CPoint point(LOWORD(dwPos), HIWORD(dwPos));
+    CPoint point(GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
     m_output_list.ScreenToClient(&point);
     LVHITTESTINFO lvinfo;
     lvinfo.pt = point;

--- a/T3000/BacnetProgram.cpp
+++ b/T3000/BacnetProgram.cpp
@@ -584,7 +584,7 @@ void CBacnetProgram::OnNMClickListProgram(NMHDR *pNMHDR, LRESULT *pResult)
 	LPNMITEMACTIVATE pNMItemActivate = reinterpret_cast<LPNMITEMACTIVATE>(pNMHDR);
 
 	DWORD dwPos=GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-	CPoint point( LOWORD(dwPos), HIWORD(dwPos));
+	CPoint point( GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
 	m_program_list.ScreenToClient(&point);
 	LVHITTESTINFO lvinfo;
 	lvinfo.pt=point;

--- a/T3000/BacnetProgramDebug.cpp
+++ b/T3000/BacnetProgramDebug.cpp
@@ -2091,7 +2091,7 @@ void CBacnetProgramDebug::OnNMClickListProgramDebug(NMHDR *pNMHDR, LRESULT *pRes
 	long lRow,lCol;
 	m_program_debug_list.Set_Edit(true);
 	DWORD dwPos=GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-	CPoint point( LOWORD(dwPos), HIWORD(dwPos));
+	CPoint point( GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
 	m_program_debug_list.ScreenToClient(&point);
 	LVHITTESTINFO lvinfo;
 	lvinfo.pt=point;

--- a/T3000/BacnetRegisterListView.cpp
+++ b/T3000/BacnetRegisterListView.cpp
@@ -1108,7 +1108,7 @@ void CBacnetRegisterListView::OnNMClickListRegisterView(NMHDR *pNMHDR, LRESULT *
     long lRow, lCol;
     m_register_view.Set_Edit(false);
     DWORD dwPos = GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-    CPoint point(LOWORD(dwPos), HIWORD(dwPos));
+    CPoint point(GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
     m_register_view.ScreenToClient(&point);
     LVHITTESTINFO lvinfo;
     lvinfo.pt = point;

--- a/T3000/BacnetScheduleTime.cpp
+++ b/T3000/BacnetScheduleTime.cpp
@@ -265,7 +265,7 @@ void CBacnetScheduleTime::OnNMClickListScheduleTime(NMHDR *pNMHDR, LRESULT *pRes
 	long lRow,lCol;
 	m_schedule_time_list.Set_Edit(false);
 	DWORD dwPos=GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-	CPoint point( LOWORD(dwPos), HIWORD(dwPos));
+	CPoint point( GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
 	m_schedule_time_list.ScreenToClient(&point);
 	LVHITTESTINFO lvinfo;
 	lvinfo.pt=point;

--- a/T3000/BacnetScreen.cpp
+++ b/T3000/BacnetScreen.cpp
@@ -571,7 +571,7 @@ void BacnetScreen::OnNMDblclkListScreen(NMHDR *pNMHDR, LRESULT *pResult)
 	
 	int device_obj_instance = g_bac_instance;
 	DWORD dwPos=GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-	CPoint point( LOWORD(dwPos), HIWORD(dwPos));
+	CPoint point( GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
 	m_screen_list.ScreenToClient(&point);
 	LVHITTESTINFO lvinfo;
 	lvinfo.pt=point;
@@ -1309,7 +1309,7 @@ void BacnetScreen::OnNMClickListScreen(NMHDR *pNMHDR, LRESULT *pResult)
 
 	
 	DWORD dwPos=GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-	CPoint point( LOWORD(dwPos), HIWORD(dwPos));
+	CPoint point( GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
 	m_screen_list.ScreenToClient(&point);
 	LVHITTESTINFO lvinfo;
 	lvinfo.pt=point;

--- a/T3000/BacnetTstatSchedule.cpp
+++ b/T3000/BacnetTstatSchedule.cpp
@@ -389,7 +389,7 @@ void CBacnetTstatSchedule::OnNMClickListBacTstatSchedule(NMHDR *pNMHDR, LRESULT 
 	long lRow, lCol;
 	m_bac_tstat_sch_list.Set_Edit(true);
 	DWORD dwPos = GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-	CPoint point(LOWORD(dwPos), HIWORD(dwPos));
+	CPoint point(GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
 	m_bac_tstat_sch_list.ScreenToClient(&point);
 	LVHITTESTINFO lvinfo;
 	lvinfo.pt = point;
@@ -553,7 +553,7 @@ void CBacnetTstatSchedule::OnNMRClickListBacTstatSchedule(NMHDR *pNMHDR, LRESULT
     long lRow, lCol;
     m_bac_tstat_sch_list.Set_Edit(true);
     DWORD dwPos = GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-    CPoint point(LOWORD(dwPos), HIWORD(dwPos));
+    CPoint point(GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
     m_bac_tstat_sch_list.ScreenToClient(&point);
     LVHITTESTINFO lvinfo;
     lvinfo.pt = point;

--- a/T3000/BacnetUserConfig.cpp
+++ b/T3000/BacnetUserConfig.cpp
@@ -319,7 +319,7 @@ void CBacnetUserConfig::OnNMClickUserList(NMHDR *pNMHDR, LRESULT *pResult)
 	long lRow,lCol;
 	m_user_config_list.Set_Edit(false);
 	DWORD dwPos=GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-	CPoint point( LOWORD(dwPos), HIWORD(dwPos));
+	CPoint point( GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
 	m_user_config_list.ScreenToClient(&point);
 	LVHITTESTINFO lvinfo;
 	lvinfo.pt=point;

--- a/T3000/BacnetVariable.cpp
+++ b/T3000/BacnetVariable.cpp
@@ -567,7 +567,7 @@ void CBacnetVariable::OnNMClickListVariable(NMHDR *pNMHDR, LRESULT *pResult)
 	long lRow,lCol;
 	m_variable_list.Set_Edit(true);
 	DWORD dwPos=GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-	CPoint point( LOWORD(dwPos), HIWORD(dwPos));
+	CPoint point( GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
 	m_variable_list.ScreenToClient(&point);
 	LVHITTESTINFO lvinfo;
 	lvinfo.pt=point;

--- a/T3000/BacnetWeeklyRoutine.cpp
+++ b/T3000/BacnetWeeklyRoutine.cpp
@@ -572,7 +572,7 @@ void BacnetWeeklyRoutine::OnNMClickListBacWeekly(NMHDR *pNMHDR, LRESULT *pResult
 	
 
 	DWORD dwPos=GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-	CPoint point( LOWORD(dwPos), HIWORD(dwPos));
+	CPoint point( GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
 	m_weeklyr_list.ScreenToClient(&point);
 	LVHITTESTINFO lvinfo;
 	lvinfo.pt=point;

--- a/T3000/BatchSNDlg.cpp
+++ b/T3000/BatchSNDlg.cpp
@@ -234,7 +234,7 @@ void CBatchSNDlg::OnNMClickList_Input(NMHDR *pNMHDR, LRESULT *pResult){
     long lRow,lCol;
     m_products_list.Set_Edit(true);
     DWORD dwPos=GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-    CPoint point( LOWORD(dwPos), HIWORD(dwPos));
+    CPoint point( GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
     m_products_list.ScreenToClient(&point);
     LVHITTESTINFO lvinfo;
     lvinfo.pt=point;

--- a/T3000/BuildingConfigration.cpp
+++ b/T3000/BuildingConfigration.cpp
@@ -1629,7 +1629,7 @@ void CBuildingConfigration::OnNMClickListBuildingConfig(NMHDR *pNMHDR, LRESULT *
     long lRow,lCol;
     m_building_config_list.Set_Edit(true);
     DWORD dwPos=GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-    CPoint point( LOWORD(dwPos), HIWORD(dwPos));
+    CPoint point( GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
     m_building_config_list.ScreenToClient(&point);
     LVHITTESTINFO lvinfo;
     lvinfo.pt=point;
@@ -1913,7 +1913,7 @@ void CBuildingConfigration::OnNMRClickListBuildingConfig(NMHDR *pNMHDR, LRESULT 
     long lRow,lCol;
     m_building_config_list.Set_Edit(true);
     DWORD dwPos=GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-    CPoint point( LOWORD(dwPos), HIWORD(dwPos));
+    CPoint point( GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
     m_building_config_list.ScreenToClient(&point);
     LVHITTESTINFO lvinfo;
     lvinfo.pt=point;
@@ -2231,7 +2231,7 @@ void CBuildingConfigration::OnNMDblclkListBuildingConfig(NMHDR *pNMHDR, LRESULT 
 	long lRow,lCol;
 	m_building_config_list.Set_Edit(true);
 	DWORD dwPos=GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-	CPoint point( LOWORD(dwPos), HIWORD(dwPos));
+	CPoint point( GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
 	m_building_config_list.ScreenToClient(&point);
 	LVHITTESTINFO lvinfo;
 	lvinfo.pt=point;

--- a/T3000/CO2_View.cpp
+++ b/T3000/CO2_View.cpp
@@ -3853,7 +3853,7 @@ void CCO2_View::OnNMClickList_Input(NMHDR *pNMHDR, LRESULT *pResult){
     long lRow,lCol;
     m_input_list.Set_Edit(true);
     DWORD dwPos=GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-    CPoint point( LOWORD(dwPos), HIWORD(dwPos));
+    CPoint point( GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
     m_input_list.ScreenToClient(&point);
     LVHITTESTINFO lvinfo;
     lvinfo.pt=point;
@@ -3960,7 +3960,7 @@ void CCO2_View::OnNMClickList_Output(NMHDR *pNMHDR, LRESULT *pResult){
     CString temp_cstring;
     m_output_list.Set_Edit(true);
     DWORD dwPos=GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-    CPoint point( LOWORD(dwPos), HIWORD(dwPos));
+    CPoint point( GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
     m_output_list.ScreenToClient(&point);
     LVHITTESTINFO lvinfo;
     lvinfo.pt=point;
@@ -3980,7 +3980,7 @@ void CCO2_View::OnNMClickList_Output(NMHDR *pNMHDR, LRESULT *pResult){
 //     long lRow,lCol;
 //     m_co2_external_sensor_list.Set_Edit(true);
 //     DWORD dwPos=GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-//     CPoint point( LOWORD(dwPos), HIWORD(dwPos));
+//     CPoint point( GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
 //     m_co2_external_sensor_list.ScreenToClient(&point);
 //     LVHITTESTINFO lvinfo;
 //     lvinfo.pt=point;

--- a/T3000/Flash_Multy.cpp
+++ b/T3000/Flash_Multy.cpp
@@ -1560,7 +1560,7 @@ void CFlash_Multy::OnNMClickListFlashMulty(NMHDR *pNMHDR, LRESULT *pResult)
     long lRow,lCol;
     m_flash_multy_list.Set_Edit(true);
     DWORD dwPos=GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-    CPoint point( LOWORD(dwPos), HIWORD(dwPos));
+    CPoint point( GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
     m_flash_multy_list.ScreenToClient(&point);
     LVHITTESTINFO lvinfo;
     lvinfo.pt=point;

--- a/T3000/ModbusToBacnetRouterDlg.cpp
+++ b/T3000/ModbusToBacnetRouterDlg.cpp
@@ -1051,7 +1051,7 @@ void CModbusToBacnetRouterDlg::OnNMClickList1(NMHDR *pNMHDR, LRESULT *pResult)
 	long lRow, lCol;
 	m_datalist.Set_Edit(true);
 	DWORD dwPos = GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-	CPoint point(LOWORD(dwPos), HIWORD(dwPos));
+	CPoint point(GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
 	m_datalist.ScreenToClient(&point);
 	LVHITTESTINFO lvinfo;
 	lvinfo.pt = point;

--- a/T3000/NewTstatSchedulesDlg.cpp
+++ b/T3000/NewTstatSchedulesDlg.cpp
@@ -865,7 +865,7 @@ void CNewTstatSchedulesDlg::OnNMClickList1(NMHDR *pNMHDR, LRESULT *pResult)
 	long lRow, lCol;
 
 	DWORD dwPos = GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-	CPoint point(LOWORD(dwPos), HIWORD(dwPos));
+	CPoint point(GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
 	WeeklyList.ScreenToClient(&point);
 	LVHITTESTINFO lvinfo;
 	lvinfo.pt = point;
@@ -1768,7 +1768,7 @@ void CNewTstatSchedulesDlg::OnNMDblclkList1(NMHDR *pNMHDR, LRESULT *pResult)
 	long lRow, lCol;
 
 	DWORD dwPos = GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-	CPoint point(LOWORD(dwPos), HIWORD(dwPos));
+	CPoint point(GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
 	WeeklyList.ScreenToClient(&point);
 	LVHITTESTINFO lvinfo;
 	lvinfo.pt = point;

--- a/T3000/ProductRegisterListView.cpp
+++ b/T3000/ProductRegisterListView.cpp
@@ -1990,7 +1990,7 @@ void CProductRegisterListView::OnNMClickList_output(NMHDR *pNMHDR, LRESULT *pRes
 	long lRow, lCol;
 	m_register_list.Set_Edit(true);
 	DWORD dwPos = GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-	CPoint point(LOWORD(dwPos), HIWORD(dwPos));
+	CPoint point(GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
 	m_register_list.ScreenToClient(&point);
 	LVHITTESTINFO lvinfo;
 	lvinfo.pt = point;
@@ -2159,7 +2159,7 @@ void CProductRegisterListView::OnNMDblclkListCustomList(NMHDR *pNMHDR, LRESULT *
 	long lRow, lCol;
 	m_register_list.Set_Edit(true);
 	DWORD dwPos = GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-	CPoint point(LOWORD(dwPos), HIWORD(dwPos));
+	CPoint point(GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
 	m_register_list.ScreenToClient(&point);
 	LVHITTESTINFO lvinfo;
 	lvinfo.pt = point;

--- a/T3000/T3ModulesOutputDlg.cpp
+++ b/T3000/T3ModulesOutputDlg.cpp
@@ -898,7 +898,7 @@ void CT3ModulesOutputDlg::OnNMClickList_output(NMHDR *pNMHDR, LRESULT *pResult)
     long lRow,lCol;
     m_outputlist.Set_Edit(true);
     DWORD dwPos=GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-    CPoint point( LOWORD(dwPos), HIWORD(dwPos));
+    CPoint point( GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
     m_outputlist.ScreenToClient(&point);
     LVHITTESTINFO lvinfo;
     lvinfo.pt=point;

--- a/T3000/T3ModulesView.cpp
+++ b/T3000/T3ModulesView.cpp
@@ -2228,7 +2228,7 @@ void CT3ModulesView::OnNMClickList_Input(NMHDR *pNMHDR, LRESULT *pResult)
     long lRow,lCol;
     m_T3_Input_List.Set_Edit(false);
     DWORD dwPos=GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-    CPoint point( LOWORD(dwPos), HIWORD(dwPos));
+    CPoint point( GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
     m_T3_Input_List.ScreenToClient(&point);
     LVHITTESTINFO lvinfo;
     lvinfo.pt=point;

--- a/T3000/TStatInputView.cpp
+++ b/T3000/TStatInputView.cpp
@@ -676,7 +676,7 @@ void CTStatInputView::OnNMClickList1(NMHDR *pNMHDR, LRESULT *pResult)
     long lRow,lCol;
     m_input_list.Set_Edit(true);
     DWORD dwPos=GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-    CPoint point( LOWORD(dwPos), HIWORD(dwPos));
+    CPoint point( GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
     m_input_list.ScreenToClient(&point);
     LVHITTESTINFO lvinfo;
     lvinfo.pt=point;

--- a/T3000/TStatOutputView.cpp
+++ b/T3000/TStatOutputView.cpp
@@ -695,7 +695,7 @@ void CTStatOutputView::OnNMClickListOutput(NMHDR *pNMHDR, LRESULT *pResult)
     long lRow,lCol;
     m_output_list.Set_Edit(true);
     DWORD dwPos=GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-    CPoint point( LOWORD(dwPos), HIWORD(dwPos));
+    CPoint point( GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
     m_output_list.ScreenToClient(&point);
     LVHITTESTINFO lvinfo;
     lvinfo.pt=point;

--- a/T3000/TstatIconSetting.cpp
+++ b/T3000/TstatIconSetting.cpp
@@ -119,7 +119,7 @@ void CTstatIconSetting::OnNMClickList1(NMHDR *pNMHDR, LRESULT *pResult)
     LPNMITEMACTIVATE pNMItemActivate = reinterpret_cast<LPNMITEMACTIVATE>(pNMHDR);
     // TODO: 在此添加控件通知处理程序代码
     DWORD dwPos = GetMessagePos();//Get which line is click by user.Set the check box, when user enter Insert it will jump to program dialog
-    CPoint point(LOWORD(dwPos), HIWORD(dwPos));
+    CPoint point(GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos));
     m_tstat_icon_list.ScreenToClient(&point);
     LVHITTESTINFO lvinfo;
     lvinfo.pt = point;


### PR DESCRIPTION
On a multimonitor setup, many things did not work properly on monitors with negative coordinates (e.g. left or above the top left corner of the main monitor).  For example on the Programs menu, clicking on any of the program lines would highlight the selected line but keep the checkbox for program 1 selected.  Double click anywhere would always only open the editor for program 1.  Replacing LOWORD/HIWORD with GET_X_LPARAM/GET_Y_LPARAM corrects this issue.

Ref: https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getmessagepos

> Important  Do not use the LOWORD or HIWORD macros to extract the x- and y- coordinates of the cursor position because these macros return incorrect results on systems with multiple monitors. Systems with multiple monitors can have negative x- and y- coordinates, and LOWORD and HIWORD treat the coordinates as unsigned quantities.