### PR TITLE
Add overwrite params to the project file

### DIFF
--- a/BacnetExplore/Yabe/TemcoStandardBacnetTool.csproj
+++ b/BacnetExplore/Yabe/TemcoStandardBacnetTool.csproj
@@ -347,7 +347,8 @@
         <!-- Use WriteLinesToFile with the Lines parameter -->
         <WriteLinesToFile
             File="$(_ConfigConstantsFile)"
-            Lines="@(_LinesToWrite)"  />
+            Lines="@(_LinesToWrite)"
+            Overwrite="true"  />
 
         <!-- Add the generated file to the list of files to compile -->
         <ItemGroup>


### PR DESCRIPTION
This pull request add overwrite parameters so that the auto generated file GeneratedAppConfigConstants will be overwritten everytime we want to change the name.

This is necessary as right now, if we change the name inside AppConfig.props, the GeneratedAppConfigConstants will be appended, which will cause compilation error.